### PR TITLE
次のトーク予約機能の修正

### DIFF
--- a/satoriya/satori/satori_load_unload.cpp
+++ b/satoriya/satori/satori_load_unload.cpp
@@ -419,18 +419,20 @@ bool	Satori::load(const string& iBaseFolder)
 #endif
 bool	Satori::Save(bool isOnUnload) {
 	GetSender().next_event();
+	
+	strmap savemap = variables;
 
 	// メンバ変数を里々変数化
 	for (std::map<int, string>::iterator it=reserved_talk.begin(); it!=reserved_talk.end() ; ++it)
-		variables[string("次から")+itos(it->first)+"回目のトーク"] = it->second;
+		savemap[string("次から")+itos(it->first)+"回目のトーク"] = it->second;
 
 	// 起動時間累計を設定
-	variables["ゴースト起動時間累計秒"] =
+	savemap["ゴースト起動時間累計秒"] =
 	    uitos(posix_get_current_sec() - sec_count_at_load + sec_count_total,"%lu");
 	// (互換用)
-	variables["ゴースト起動時間累計ミリ秒"] =
+	savemap["ゴースト起動時間累計ミリ秒"] =
 	    uitos((posix_get_current_sec() - sec_count_at_load + sec_count_total)*1000,"%lu");
-	variables["ゴースト起動時間累計(ms)"] =
+	savemap["ゴースト起動時間累計(ms)"] =
 	    uitos((posix_get_current_sec() - sec_count_at_load + sec_count_total)*1000,"%lu");
 
 	if ( isOnUnload ) {
@@ -455,7 +457,7 @@ bool	Satori::Save(bool isOnUnload) {
 	string  data;
 
 	out << ENCODE(line) << std::endl;
-	for (strmap::const_iterator it=variables.begin() ; it!=variables.end() ; ++it) {
+	for (strmap::const_iterator it= savemap.begin() ; it!= savemap.end() ; ++it) {
 		string	key = zen2han(it->first);
 		if ( key[0]=='S' && aredigits(key.c_str()+1) ) {
 			continue;

--- a/satoriya/satori/satori_tool.cpp
+++ b/satoriya/satori/satori_tool.cpp
@@ -979,9 +979,9 @@ int	Satori::system_variable_operation_real(string key, string value, string* res
 				else {
 					++it;
 				}
-				return 1; //実行＋変数設定
 			}
 		}
+		return -1; //◆実行：変数設定しない
 	}
 	
 	if ( key == "SAORI引数の計算" ) {


### PR DESCRIPTION
* ＄トーク予約のキャンセル をセーブデータに持ってしまう問題を修正
* ＄手動セーブ をかけると ＄次のトーク が喋り終えてもセーブデータに残り次回起動時に再予約されてしまう問題を修正