### PR TITLE
POSIXで戻り値が無いことによるエラーの修正

### DIFF
--- a/satoriya/_/Sender.cpp
+++ b/satoriya/_/Sender.cpp
@@ -165,7 +165,7 @@ bool Sender::send(int mode,const char* iString)
 bool Sender::send_to_window(const int mode,const char* theBuf)
 {
 #ifdef POSIX
-	fprintf(stderr, theBuf);
+	fprintf(stderr, "%s", theBuf);
 	fprintf(stderr, "\n");
 #else
 	if ( !auto_init() ) { return false; }

--- a/satoriya/_/Sender.cpp
+++ b/satoriya/_/Sender.cpp
@@ -167,6 +167,7 @@ bool Sender::send_to_window(const int mode,const char* theBuf)
 #ifdef POSIX
 	fprintf(stderr, "%s", theBuf);
 	fprintf(stderr, "\n");
+	return true;
 #else
 	if ( !auto_init() ) { return false; }
 	


### PR DESCRIPTION
Fedora44で里々ゴーストを終了した時にセグフォが発生していたのを修正しました。
ついでにFormat String Attackが出来ていたのを修正しました。